### PR TITLE
Changed Zephyr's `z_sleep_ms` to allow for sleeps longer than 1 second

### DIFF
--- a/src/system/zephyr/system.c
+++ b/src/system/zephyr/system.c
@@ -103,7 +103,13 @@ int8_t _z_condvar_wait(_z_condvar_t *cv, _z_mutex_t *m) { return pthread_cond_wa
 /*------------------ Sleep ------------------*/
 int z_sleep_us(unsigned int time) { return usleep(time); }
 
-int z_sleep_ms(unsigned int time) { return usleep(time * 1000U); }
+int z_sleep_ms(unsigned int time) {
+    struct timespec ts;
+    ts.tv_sec = time / 1000ll;
+    ts.tv_nsec = (time - (ts.tv_sec * 1000)) * 1000 * 1000;
+
+    return nanosleep(&ts, NULL);
+}
 
 int z_sleep_s(unsigned int time) { return sleep(time); }
 


### PR DESCRIPTION
`z_sleep_ms` use zephyr's `nanosleep` because the previously used `usleep` doesn't support sleeps for more than 1 second.

The thinking was to keep using Zephyr's POSIX API as zenoh-pico was already doing for `z_sleep_us` and `z_sleep_s` and because the now deprecated [`usleep`](https://man7.org/linux/man-pages/man3/usleep.3.html) recommends using `nanosleep` instead.

Related to #156 